### PR TITLE
typo in test for environment variables

### DIFF
--- a/index.py
+++ b/index.py
@@ -225,7 +225,7 @@ def lambda_handler(event, context):
 				
 				global AUTOSCALINGPOLICYOUT_ARN
 				global AUTOSCALINGPOLICYIN_ARN
-				if 'AutoScalingPolicyOut' and 'AutoScalingPolicyIn' not in os.environ:
+				if 'AutoScalingPolicyOut' not in os.environ or 'AutoScalingPolicyIn' not in os.environ:
 					autoscaling_policy_arn(context)
 				AUTOSCALINGPOLICYOUT_ARN = os.environ['AutoScalingPolicyOut']
 				AUTOSCALINGPOLICYIN_ARN = os.environ['AutoScalingPolicyIn']


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix for small typo in testing whether `AutoScalingPolicyOut` and `AutoScalingPolicyIn` exist as environment variables

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
